### PR TITLE
tests: fix error reporting from Mkdir calls

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -775,7 +775,7 @@ func TestFsnotifyRenameToOverwrite(t *testing.T) {
 	defer os.RemoveAll(testDir)
 
 	// Create directory to get file
-	if err := os.Mkdir(testDirFrom, 0777) != nil {
+	if err := os.Mkdir(testDirFrom, 0777); err != nil {
 		t.Fatalf("Failed to create test directory: %s", err)
 	}
 	defer os.RemoveAll(testDirFrom)


### PR DESCRIPTION
Whenever the creation of a directory fails, it was trying to report an
error from an outer scope.
