### PR TITLE
May your badge be forever green

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # File system notifications for Go
 
+[![Build Status](https://goci.herokuapp.com/project/image/github.com/howeyc/fsnotify)](http://goci.me/project/github.com/howeyc/fsnotify)
+
 [GoDoc](http://go.pkgdoc.org/github.com/howeyc/fsnotify)
 
 Cross platform, works on:


### PR DESCRIPTION
Adds [GoCI](http://goci.me/) badge to indicate that tests pass (on Linux).

There are some other alternatives:
### Drone.io

Really slick to setup purely via the [web interface](https://drone.io/), but it doesn't provide any real advantages over GoCI for this project (we have no databases). The default config should work with this flat file structure, but [here are some tweaks](https://gist.github.com/nathany/6402146) based on the Travis CI documentation.

It does integrate with [Coveralls](https://coveralls.io/) for code coverage, if you find that useful. See [this example](https://coveralls.io/r/gophertown/looper?branch=master), click a build # and than a file to drill down.
### Travis CI

Travis will let us test against multiple versions of Go (eg. 1.1 and tip) and it integrates with pull requests to say whether or not it's safe to merge (again, only testing on Linux).

It requires an administrator to [set up a GitHub Service Hook](http://about.travis-ci.org/docs/user/getting-started/) and a `.travis.yml` file which might look something like this:

``` yaml
# run travis-lint before committing changes
language: go

go:
  - 1.1
  - tip

matrix:
  allow_failures:
    - go: tip
```
