### PR TITLE
Update package path in example code.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,8 +6,7 @@ package fsnotify_test
 
 import (
 	"log"
-
-	"code.google.com/p/go.exp/fsnotify"
+	"github.com/howeyc/fsnotify"
 )
 
 func ExampleNewWatcher() {


### PR DESCRIPTION
I don't have a checkout of `code.google.com/p/go.exp/fsnotify` in my GOPATH, so running the fsnotify test suite fails:

```
$ go test github.com/howeyc/fsnotify
# github.com/howeyc/fsnotify
example_test.go:10:2: cannot find package "code.google.com/p/go.exp/fsnotify" in any of:
    /usr/local/Cellar/go/1.1.1/src/pkg/code.google.com/p/go.exp/fsnotify (from $GOROOT)
    /Users/ph/go/src/code.google.com/p/go.exp/fsnotify (from $GOPATH)
```

This pull request fixes that issue.
