### PR TITLE
Fix deadlock on BSD

### DIFF
--- a/fsnotify_bsd.go
+++ b/fsnotify_bsd.go
@@ -245,12 +245,12 @@ func (w *Watcher) removeWatch(path string) error {
 	watchEntry := &w.kbuf[0]
 	syscall.SetKevent(watchEntry, watchfd, syscall.EVFILT_VNODE, syscall.EV_DELETE)
 	success, errno := syscall.Kevent(w.kq, w.kbuf[:], nil, nil)
+	w.bufmut.Unlock()
 	if success == -1 {
 		return os.NewSyscallError("kevent_rm_watch", errno)
 	} else if (watchEntry.Flags & syscall.EV_ERROR) == syscall.EV_ERROR {
 		return errors.New("kevent rm error")
 	}
-	w.bufmut.Unlock()
 	syscall.Close(watchfd)
 	w.wmut.Lock()
 	delete(w.watches, path)


### PR DESCRIPTION
I'm using fsnotify for [a project](https://github.com/cespare/reflex) where I set up recursive watches using the usual directory walking song and dance. I noticed that on Mac OS fsnotify would quickly get into a bad state where I'd stop receiving any events.

It turned out that fsnotify was deadlocking because mutexes weren't always properly released.

The `removeWatch` routine could return without releasing the lock on `w.bufmut`. This change unlocks the mutex before checking for errors.
