### PR TITLE
Remove current implementation of WatchFlags

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -7,77 +7,13 @@ package fsnotify
 
 import "fmt"
 
-const (
-	FSN_CREATE = 1
-	FSN_MODIFY = 2
-	FSN_DELETE = 4
-	FSN_RENAME = 8
-
-	FSN_ALL = FSN_MODIFY | FSN_DELETE | FSN_RENAME | FSN_CREATE
-)
-
-// Purge events from interal chan to external chan if passes filter
-func (w *Watcher) purgeEvents() {
-	for ev := range w.internalEvent {
-		sendEvent := false
-		w.fsnmut.Lock()
-		fsnFlags := w.fsnFlags[ev.Name]
-		w.fsnmut.Unlock()
-
-		if (fsnFlags&FSN_CREATE == FSN_CREATE) && ev.IsCreate() {
-			sendEvent = true
-		}
-
-		if (fsnFlags&FSN_MODIFY == FSN_MODIFY) && ev.IsModify() {
-			sendEvent = true
-		}
-
-		if (fsnFlags&FSN_DELETE == FSN_DELETE) && ev.IsDelete() {
-			sendEvent = true
-		}
-
-		if (fsnFlags&FSN_RENAME == FSN_RENAME) && ev.IsRename() {
-			sendEvent = true
-		}
-
-		if sendEvent {
-			w.Event <- ev
-		}
-
-		// If there's no file, then no more events for user
-		// BSD must keep watch for internal use (watches DELETEs to keep track
-		// what files exist for create events)
-		if ev.IsDelete() {
-			w.fsnmut.Lock()
-			delete(w.fsnFlags, ev.Name)
-			w.fsnmut.Unlock()
-		}
-	}
-
-	close(w.Event)
-}
-
 // Watch a given file path
 func (w *Watcher) Watch(path string) error {
-	w.fsnmut.Lock()
-	w.fsnFlags[path] = FSN_ALL
-	w.fsnmut.Unlock()
-	return w.watch(path)
-}
-
-// Watch a given file path for a particular set of notifications (FSN_MODIFY etc.)
-func (w *Watcher) WatchFlags(path string, flags uint32) error {
-	w.fsnmut.Lock()
-	w.fsnFlags[path] = flags
-	w.fsnmut.Unlock()
 	return w.watch(path)
 }
 
 // Remove a watch on a file
 func (w *Watcher) RemoveWatch(path string) error {
-	w.fsnmut.Lock()
-	delete(w.fsnFlags, path)
-	w.fsnmut.Unlock()
 	return w.removeWatch(path)
 }
 


### PR DESCRIPTION
removes fsnFlags, purgeEvents and internalEvent channel
- current implementation doesn't take advantage of OS for efficiency
- provides little benefit over filtering events as they are received, but has  extra bookkeeping and mutexes
- no tests for the current implementation
- not fully implemented on Windows https://github.com/howeyc/fsnotify/issues/93#issuecomment-39285195

TODO: go.exp CL for this.
