### PR TITLE
Feature: Add FSN type.

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -124,6 +124,10 @@ func (e *FileEvent) String() string {
 		events += "|" + "ATTRIB"
 	}
 
+	if e.IsCloseWrite() {
+		events += "|" + "CLOSE_WRITE"
+	}
+
 	if len(events) > 0 {
 		events = events[1:]
 	}

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -47,7 +47,7 @@ const (
 	sys_IN_MOVE_SELF     uint32 = syscall.IN_MOVE_SELF
 	sys_IN_OPEN          uint32 = syscall.IN_OPEN
 
-	sys_AGNOSTIC_EVENTS = sys_IN_MOVED_TO | sys_IN_MOVED_FROM | sys_IN_CREATE | sys_IN_ATTRIB | sys_IN_MODIFY | sys_IN_MOVE_SELF | sys_IN_DELETE | sys_IN_DELETE_SELF
+	sys_AGNOSTIC_EVENTS = sys_IN_CLOSE_WRITE | sys_IN_MOVED_TO | sys_IN_MOVED_FROM | sys_IN_CREATE | sys_IN_ATTRIB | sys_IN_MODIFY | sys_IN_MOVE_SELF | sys_IN_DELETE | sys_IN_DELETE_SELF
 
 	// Special events
 	sys_IN_ISDIR      uint32 = syscall.IN_ISDIR
@@ -85,6 +85,11 @@ func (e *FileEvent) IsRename() bool {
 // IsAttrib reports whether the FileEvent was triggered by a change in the file metadata.
 func (e *FileEvent) IsAttrib() bool {
 	return (e.mask & sys_IN_ATTRIB) == sys_IN_ATTRIB
+}
+
+// IsCloseWrite reports whether the FileEvent was triggered by closing the changed file.
+func (e *FileEvent) IsCloseWrite() bool {
+	return (e.mask & sys_IN_CLOSE_WRITE) == sys_IN_CLOSE_WRITE
 }
 
 type watch struct {


### PR DESCRIPTION
In some cases, we make sure a file change is finished before we read it.
So how do you do that? Try using IN_CLOSE_WRITE instead.
I'v done a lot of testing on Linux.